### PR TITLE
Updating policy name

### DIFF
--- a/terraform/aws-groups.tf
+++ b/terraform/aws-groups.tf
@@ -10,12 +10,12 @@ module "iam_read_only_group" {
 }
 
 // Create iam services admin group
-module "iam_services_admin_group" {
+module "iam_services_supervisor_group" {
   source = "./modules/aws-groups"
 
   group_name = "iam-services-admin-group"
   policy_arn = {
-    "IAMServicesAdmin" = module.aws_custom_policies.policy_arns["IAMServicesSupervisor"]
+    "IAMServicesSupervisor" = module.aws_custom_policies.policy_arns["IAMServicesSupervisor"]
   }
 }
 

--- a/terraform/aws-groups.tf
+++ b/terraform/aws-groups.tf
@@ -13,7 +13,7 @@ module "iam_read_only_group" {
 module "iam_services_supervisor_group" {
   source = "./modules/aws-groups"
 
-  group_name = "iam-services-admin-group"
+  group_name = "iam-services-supervisor-group"
   policy_arn = {
     "IAMServicesSupervisor" = module.aws_custom_policies.policy_arns["IAMServicesSupervisor"]
   }


### PR DESCRIPTION
What changed?
- We updated the policy name to replace 'admin' with 'supervisor' and I missed a few places, so that's the only change

The plan should show the 'admin' policy removed and then the new policy (that was applied previously) will be assigned to the group