### PR TITLE
updating group name in assignment

### DIFF
--- a/terraform/aws-users.tf
+++ b/terraform/aws-users.tf
@@ -105,5 +105,5 @@ module "iam_user_chelseyb" {
     "Project"      = "devops-security"
     "Access Level" = "1"
   }
-  user_groups = ["read-only-group", "iam-services-admin-group"]
+  user_groups = ["read-only-group", "iam-services-supervisor-group"]
 }


### PR DESCRIPTION
## What changed?
- after changing the group and policy names, I didn't update the name of the group users were assigned to...correcting that