### PR TITLE
16 add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue-form-with-dependency.yml
+++ b/.github/ISSUE_TEMPLATE/blank-issue-form-with-dependency.yml
@@ -1,0 +1,33 @@
+name: 'Blank Issue Form with Dependency'
+description: 'Standard HackforLA issue form with dependency'
+labels: ['role missing', 'Complexity: Missing', 'Feature Missing', 'size: missing','Draft']
+body:
+  - type: textarea
+    id: dependency
+    attributes:
+      label: Dependency
+      description: 'Add dependencies (ideally by issue #)'
+      value: '- [ ]'
+    validations:
+      required: true
+  - type: input
+    id: overview
+    attributes:
+      label: Overview
+      description: Clearly state the purpose of this issue in 2 sentences or less
+    validations:
+      required: true
+  - type: textarea
+    id: action-items
+    attributes:
+      label: Action Items
+      description: "List the research to be done, or the steps to be completed. Note: If the steps can be divided into tasks for more than one person, we recommend dividing it up into separate issues, or assigning it as a pair programming task."
+    validations:
+      required: true
+  - type: textarea
+    id: resources-instructions
+    attributes:
+      label: "Resources/Instructions"
+      description: "Provide links to resources or instructions that may help with this issue. This can include files to be worked on, external sites with solutions, documentation, etc."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/blank-issue-form-with-no-dependency.yml
+++ b/.github/ISSUE_TEMPLATE/blank-issue-form-with-no-dependency.yml
@@ -1,0 +1,26 @@
+name: 'Blank Issue Form with No Dependency'
+description: 'Standard HackforLA issue form with no dependency'
+labels: ['role missing', 'Complexity: Missing', 'Feature Missing', 'size: missing','Draft']
+
+body:
+  - type: input
+    id: overview
+    attributes:
+      label: Overview
+      description: Clearly state the purpose of this issue in 2 sentences or less
+    validations:
+      required: true
+  - type: textarea
+    id: action-items
+    attributes:
+      label: Action Items
+      description: "List the research to be done, or the steps to be completed. Note: If the steps can be divided into tasks for more than one person, we recommend dividing it up into separate issues, or assigning it as a pair programming task."
+    validations:
+      required: true
+  - type: textarea
+    id: resources-instructions
+    attributes:
+      label: "Resources/Instructions"
+      description: "Provide links to resources or instructions that may help with this issue. This can include files to be worked on, external sites with solutions, documentation, etc."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/blank-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue-template.md
@@ -1,0 +1,18 @@
+---
+name: Blank Issue Template
+about: 'Standard HackforLA issue template '
+title: ''
+labels: 'Complexity: Missing, Feature Missing, role missing, size: missing'
+assignees: ''
+
+---
+
+### Overview
+REPLACE THIS TEXT - Clearly state the purpose of this issue in 2 sentences or less.  We write ours a modified user story in this format: _We need to do X for Y reason._
+
+### Action Items
+REPLACE THIS TEXT - List the research to be done, or the steps to be completed.
+Note: If the steps can be divided into tasks for more than one person, we recommend dividing it up into separate issues, or assigning it as a pair programming task.
+
+### Resources/Instructions
+REPLACE THIS TEXT - Provide links to resources or instructions that may help with this issue. This can include files to be worked on, external sites with solutions, documentation, etc.


### PR DESCRIPTION
- Fixes #16 
- add blank issue form with no dependency, add blank issue form with dependency, add blank issue template inside of .github/ISSUE_TEMPLATE directory

