### PR TITLE
add gha oidc module and invoke for incubator; add tyler for HomeUniteUs

### DIFF
--- a/terraform/aws-gha-oidc-providers.tf
+++ b/terraform/aws-gha-oidc-providers.tf
@@ -1,0 +1,13 @@
+module "iam_oidc_gha_incubator" {
+  source             = "./modules/aws-gha-oidc-providers"
+
+  role_name          = "gha-incubator"
+  use_wildcard       = true
+  allow_pull_request = true
+  github_branch      = "refs/heads/*" # allows any branch
+  github_repo        = "hackforla/incubator"
+
+  policy_arns = [
+    "arn:aws:iam::aws:policy/AdministratorAccess"
+  ]
+}

--- a/terraform/aws-users.tf
+++ b/terraform/aws-users.tf
@@ -9,6 +9,17 @@ module "iam_user_JimmyJuarez10" {
   user_groups = ["read-only-group"]
 }
 
+module "iam_user_tylerthome" {
+  source = "./modules/aws-users"
+
+  user_name = "tyler.thome"
+  user_tags = {
+    "Project"      = "home-unite-us"
+    "Access Level" = "1"
+  }
+  user_groups = ["read-only-group"]
+}
+
 module "iam_user_brittanyms" {
   source = "./modules/aws-users"
 

--- a/terraform/modules/aws-gha-oidc-providers/main.tf
+++ b/terraform/modules/aws-gha-oidc-providers/main.tf
@@ -1,0 +1,80 @@
+locals {
+  oidc_aws_audience = "sts.amazonaws.com"
+  oidc_github_idp   = "token.actions.githubusercontent.com"
+
+  # compose the OIDC subject using opinionated set of claims
+  # TODO: discuss alternative with maintainers
+  #   see 'claims_supported' for all possibilities (some of which would require custom GHA):
+  #      https://token.actions.githubusercontent.com/.well-known/openid-configuration
+  ordered_claim_names = [
+    "repo", "environment", "ref"
+  ]
+
+  # map user-supplied args to claim names, some of which may be empty
+  claims_with_values = zipmap(local.ordered_claim_names, [
+    var.github_repo, var.github_environment, var.github_branch
+  ])
+
+  # construct 'sub' claim parts by selecting non-empty arg values, then combine
+  claims = [
+    for claim in local.ordered_claim_names : format(
+      "%s:%s",
+      claim,
+      local.claims_with_values[claim]
+    ) if length(local.claims_with_values[claim]) > 0
+  ]
+
+  oidc_gha_sub = join(":", var.allow_pull_request ? concat(
+    local.claims, ["pull_request"]
+    ) : local.claims
+  )
+
+  /*
+    Alternative, which would place more responsibility on user to specify valid OIDC claims:
+     
+      `oidc_expected_claims = join(":", [for k,v in var.claim_patterns : "${k}:${v}"])`
+  */
+
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://${local.oidc_github_idp}"
+
+  client_id_list = [
+    local.oidc_aws_audience
+  ]
+
+  thumbprint_list = ["1b511abead59c6ce207077c0bf0e0043b1382612"]
+}
+
+resource "aws_iam_role" "github_actions_oidc" {
+
+  name                = var.role_name
+  managed_policy_arns = var.policy_arns
+
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [{
+      "Effect" : "Allow",
+      "Principal" : {
+        "Federated" : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.oidc_github_idp}"
+      },
+      "Action" : "sts:AssumeRoleWithWebIdentity",
+      "Condition" : var.use_wildcard ? {
+        "StringLike" : {
+          "token.actions.githubusercontent.com:sub" : local.oidc_gha_sub
+        },
+        "StringEquals" : {
+          "token.actions.githubusercontent.com:aud" : local.oidc_aws_audience,
+        }
+        } : {
+        "StringEquals" : {
+          "token.actions.githubusercontent.com:aud" : local.oidc_aws_audience,
+          "token.actions.githubusercontent.com:sub" : local.oidc_gha_sub
+        }
+      }
+    }]
+  })
+}

--- a/terraform/modules/aws-gha-oidc-providers/outputs.tf
+++ b/terraform/modules/aws-gha-oidc-providers/outputs.tf
@@ -1,0 +1,9 @@
+output "role_arn" {
+  value       = aws_iam_role.github_actions_oidc.arn
+  description = "The ARN of the IAM role for the federated identity"
+}
+
+output "provider_arn" {
+  value       = aws_iam_openid_connect_provider.github_actions.arn
+  description = "The ARN of the OIDC provider"
+}

--- a/terraform/modules/aws-gha-oidc-providers/variables.tf
+++ b/terraform/modules/aws-gha-oidc-providers/variables.tf
@@ -1,0 +1,56 @@
+variable "role_name" {
+  description = "The name of the IAM role"
+  type        = string
+}
+
+variable "github_repo" {
+  description = "The repository name (or name wildcard pattern if use_wildcard=true)"
+  type        = string
+
+  validation {
+    condition     = can(regex("hackforla/.*", var.github_repo))
+    error_message = "The github_repo argument must begin with 'hackforla/'"
+  }
+}
+
+variable "github_branch" {
+  description = "The branch name (or name wildcard pattern if use_wildcard=true)"
+  type        = string
+
+  validation {
+    condition     = can(regex("refs/(heads|tags)/.*", var.github_branch))
+    error_message = "The github_branch argument must begin with 'refs/heads/' or 'refs/tags/"
+  }
+}
+
+variable "github_environment" {
+  description = "The environment name (optional)"
+  type        = string
+  default     = ""
+}
+
+variable "policy_arns" {
+  description = "The ARN of the policy to attach to the role"
+  type        = list(string)
+}
+
+variable "use_wildcard" {
+  description = "Specifies whether OIDC claim subject should use wildcard pattern"
+  type        = bool
+}
+
+variable "allow_pull_request" {
+  description = "Authorize the token for pull requests"
+  type        = bool
+  default     = false
+}
+
+/*
+    Alternative, which would place more responsibility on user to specify valid OIDC claims:
+
+      `variable "claim_patterns" {
+        description = "Specifies arbitrary "
+        type = map(string)
+      }`
+  */
+


### PR DESCRIPTION
### What changes did you make?
  - Add OIDC federated creds for incubator terraform action runners to Hack for LA AWS devops-security configurations
  - Add `tyler.thome` with read-only access to common AWS account

### Rationale behind the changes?
  - Enable terraform operations from the incubator repo (details pending discussion)

### Testing done for these changes
  - Terraform tested in separate account for new tf resources

### What did you learn or can share that is new?(optional)
* https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect
* https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html#idp_oidc_Create_GitHub
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider
* https://github.com/aws-actions/configure-aws-credentials#configure-aws-credentials-for-github-actions

### Notes
 - Possibly related to #23 