### PR TITLE
adding tf extension as requirement for plan

### DIFF
--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main  # or any other branch you want to trigger the deployment
+    paths: 
+      - '**/*.tf'
 
 jobs:
   terraform-plan:


### PR DESCRIPTION
When GitHub actions run, we only want .tf extensions to set off the plan