### PR TITLE
use dynamic data pull for GHA cert thumbprint

### DIFF
--- a/terraform/modules/aws-gha-oidc-providers/main.tf
+++ b/terraform/modules/aws-gha-oidc-providers/main.tf
@@ -39,6 +39,10 @@ locals {
 
 data "aws_caller_identity" "current" {}
 
+data "tls_certificate" "github_actions" {
+  url = "https://${local.oidc_github_idp}"
+}
+
 resource "aws_iam_openid_connect_provider" "github_actions" {
   url = "https://${local.oidc_github_idp}"
 
@@ -46,7 +50,7 @@ resource "aws_iam_openid_connect_provider" "github_actions" {
     local.oidc_aws_audience
   ]
 
-  thumbprint_list = ["1b511abead59c6ce207077c0bf0e0043b1382612"]
+  thumbprint_list = [data.tls_certificate.github_actions.certificates[0].sha1_fingerprint]
 }
 
 resource "aws_iam_role" "github_actions_oidc" {


### PR DESCRIPTION
### What changes did you make?
  - Add a `data` block for the GitHub Actions token issuer's TLS certificate

### Rationale behind the changes?
  - Avoid hard-coding cert thumbprint in shared module, as this is subject to change

### Testing done for these changes
  - None: existing implementation encounters an IAM error, suggesting this role assignment is no longer valid for the integration

### What did you learn or can share that is new?(optional)
N/A

### Notes
 - This *may* be something we can eliminate altogether when we have time to test it online. This blog post suggests that AWS may have integrated the GHA issuer internally to avoid thumbprint rotation by admins: https://github.blog/changelog/2023-07-13-github-actions-oidc-integration-with-aws-no-longer-requires-pinning-of-intermediate-tls-certificates/
