### PR TITLE
remove unsupported `pull_request` option

### DIFF
--- a/terraform/aws-gha-oidc-providers.tf
+++ b/terraform/aws-gha-oidc-providers.tf
@@ -3,7 +3,6 @@ module "iam_oidc_gha_incubator" {
 
   role_name          = "gha-incubator"
   use_wildcard       = true
-  allow_pull_request = true
   github_branch      = "refs/heads/*" # allows any branch
   github_repo        = "hackforla/incubator"
 

--- a/terraform/modules/aws-gha-oidc-providers/variables.tf
+++ b/terraform/modules/aws-gha-oidc-providers/variables.tf
@@ -39,18 +39,3 @@ variable "use_wildcard" {
   type        = bool
 }
 
-variable "allow_pull_request" {
-  description = "Authorize the token for pull requests"
-  type        = bool
-  default     = false
-}
-
-/*
-    Alternative, which would place more responsibility on user to specify valid OIDC claims:
-
-      `variable "claim_patterns" {
-        description = "Specifies arbitrary "
-        type = map(string)
-      }`
-  */
-


### PR DESCRIPTION
### What changes did you make?
 - Remove the `pull_request` component of the `sub` claim referenced by the IAM policy for the OIDC provider

### Rationale behind the changes?
  - This fixes a flawed IAM configuration caused by including `pull_request` in while composing the `sub` claim

### Testing done for these changes
  - Intended for immediate use in the hackforla/incubator repository, but an equivalent configuration was tested and validated in the hackforla/HomeUniteUs repository

### What did you learn or can share that is new?(optional)
Not all of the available OIDC claims listed in [GitHub Actions OIDC configuration](https://token.actions.githubusercontent.com/.well-known/openid-configuration) 

### Notes
 - This can be further evaluated as needed, comments are included in terraform linking relevant docs
