### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ terraform.rc
 
 # Ignore metadata files
 *.tfstate.lock.info
+
+#Ignore lock file
+*.terraform.lock.hcl


### PR DESCRIPTION
Add the terraform.lock.hcl file to the gitignore

Fixes #replace_this_text_with_the_issue_number

### What changes did you make?
  - Added to the gitignore file
  -
  -

### Why did you make the changes (we will use this info to test)?
  - Terraform 0.14 and beyond will generate a teraform.lock.hcl file to indicate package versions, 
  - While we can commit a single .lock.hcl file for everyone to use, we will instead avoid committing this file to github so every u.er can generate it themselves when using terraform init. (This is the behavior of Terraform 0.13 and below)
  -

