### PR TITLE
Updated Docs to Include Specific Instructions on Authenticating AWS CLI using credentials

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ If you've already completed these steps or you aren't making Terraform changes, 
   ***
 The below steps must be completed in order to authenticate to AWS locally via the command line interface (CLI):
 - [Install AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) 
-- [Set up the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html)
+- [Set up the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-authentication-user.html)
 
 <sub>[Back to Top](#)</sub>
 ***


### PR DESCRIPTION
Fixes #97 

### What changes did you make?
  - Updated link to include specific authentication instructions for us in setting up AWS CLI. 

### Why did you make the changes (we will use this info to test)?
  - The previous link was hard to follow with current onboarding methods. This link is direct and to the point.
  -  To do: update link in onboarding workup / first-issue. I would, but I cannot find the document or don't have access.

