### PR TITLE
Add terraform.tfstate to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Ignore local development variable file
 backend.tfvars
+terraform.tfstate
 
 # Ignore override files
 *.tfoverride
@@ -20,5 +21,5 @@ terraform.rc
 # Ignore metadata files
 *.tfstate.lock.info
 
-#Ignore lock file
+# Ignore lock file
 *.terraform.lock.hcl


### PR DESCRIPTION
Fixes #104

### What changes did you make?
  - Add terraform.tfstate to .gitignore

### Why did you make the changes (we will use this info to test)?
  - During onboarding, some users wind up committing their local terraform.tfstate file to the repo. This change will cause git to ignore the file.