### PR TITLE
Create mfa enforcement policy and add it to existing groups

### DIFF
--- a/terraform/aws-custom-policies.tf
+++ b/terraform/aws-custom-policies.tf
@@ -4,6 +4,10 @@ module "aws_custom_policies" {
     "IAMServicesSupervisor" = {
       description = "Policy granting IAM services admins permissions to make changes to user accounts"
       filename    = "level-4-iam-services-supervisor-policy.json"
+    },
+    "EnforceMFAForUsers" = {
+      description = "Policy enforcing MFA for devops security users"
+      filename    = "enforce-mfa-for-users-policy.json"
     }
   }
 }

--- a/terraform/aws-custom-policies/enforce-mfa-for-users-policy.json
+++ b/terraform/aws-custom-policies/enforce-mfa-for-users-policy.json
@@ -1,0 +1,25 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+      {
+          "Sid": "EnforceMFAForUsers",
+          "Effect": "Deny",
+          "NotAction": [
+              "iam:CreateVirtualMFADevice",
+              "iam:EnableMFADevice",
+              "iam:GetUser",
+              "iam:GetMFADevice",
+              "iam:ListMFADevices",
+              "iam:ListVirtualMFADevices",
+              "iam:ResyncMFADevice",
+              "sts:GetSessionToken"
+          ],
+          "Resource": "*",
+          "Condition": {
+              "BoolIfExists": {
+                  "aws:MultiFactorAuthPresent": "false"
+              }
+          }
+      }
+  ]
+}

--- a/terraform/aws-groups.tf
+++ b/terraform/aws-groups.tf
@@ -5,7 +5,8 @@ module "iam_read_only_group" {
   group_name = "read-only-group"
   policy_arn = {
     "ReadOnlyAccess"        = "arn:aws:iam::aws:policy/ReadOnlyAccess",
-    "IAMUserChangePassword" = "arn:aws:iam::aws:policy/IAMUserChangePassword"
+    "IAMUserChangePassword" = "arn:aws:iam::aws:policy/IAMUserChangePassword",
+    "EnforceMFAForUsers"    = module.aws_custom_policies.policy_arns["EnforceMFAForUsers"]
   }
 }
 
@@ -15,7 +16,8 @@ module "iam_services_supervisor_group" {
 
   group_name = "iam-services-supervisor-group"
   policy_arn = {
-    "IAMServicesSupervisor" = module.aws_custom_policies.policy_arns["IAMServicesSupervisor"]
+    "IAMServicesSupervisor" = module.aws_custom_policies.policy_arns["IAMServicesSupervisor"],
+    "EnforceMFAForUsers"    = module.aws_custom_policies.policy_arns["EnforceMFAForUsers"]
   }
 }
 


### PR DESCRIPTION
Fixes #22 

### What changes did you make?
  - Use terraform to create a new policy `EnforceMFAForUsers`. 
  - Use terraform to attach the new policy to all existing groups.

### Why did you make the changes (we will use this info to test)?
  - We want to enforce MFA authentication for all users.

<details>
<summary>New Policy Created</summary>
<img width="836" height="774" alt="Screenshot 2025-08-13 at 5 09 31 PM" src="https://github.com/user-attachments/assets/e84a03ab-db4b-45ba-946b-6b6f7af3bd35" />
</details>

<details>
<summary>Group Policies Updated</summary>
<img width="653" height="657" alt="Screenshot 2025-08-13 at 5 08 06 PM" src="https://github.com/user-attachments/assets/9eefb3cd-a14e-4526-ac95-6c30cf9c0f0d" />
<img width="619" height="696" alt="Screenshot 2025-08-13 at 5 08 39 PM" src="https://github.com/user-attachments/assets/5f82d0c0-c3c9-4742-aa47-1630dfa85718" />
</details>

<details>
<summary>Users without MFA have limited access</summary>
<img width="1437" height="882" alt="Screenshot 2025-08-13 at 5 27 25 PM" src="https://github.com/user-attachments/assets/d6e4534c-7b52-4e81-aacd-bd1481bc0284" />
</details>


