### PR TITLE
Separate Terraform plan and apply roles for incubator

### DIFF
--- a/terraform/aws-gha-oidc-providers.tf
+++ b/terraform/aws-gha-oidc-providers.tf
@@ -62,8 +62,7 @@ resource "aws_iam_role" "incubator_tf_apply" {
           }
           StringLike = {
             "token.actions.githubusercontent.com:sub" = [
-              "repo:hackforla/incubator:ref:refs/heads/main",
-              "repo:hackforla/incubator:pull_request"
+              "repo:hackforla/incubator:ref:refs/heads/main"
             ]
           }
         }

--- a/terraform/aws-gha-oidc-providers.tf
+++ b/terraform/aws-gha-oidc-providers.tf
@@ -11,18 +11,39 @@ module "iam_oidc_gha_incubator" {
   ]
 
 }
-module "iam_oidc_incubator_tf_plan" {
-  source = "./modules/aws-gha-oidc-providers"
+resource "aws_iam_role" "incubator_tf_plan" {
+  name = "incubator-tf-plan"
 
-  role_name     = "incubator-tf-plan"
-  use_wildcard  = true
-  github_branch = "refs/heads/*" # concerning IAM audit, ok, as it is read-only
-  github_repo   = "hackforla/incubator"
-
-  policy_arns = [
-    "arn:aws:iam::aws:policy/ReadOnlyAccess"
-  ]
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Principal = {
+          Federated = module.iam_oidc_gha_incubator.provider_arn
+        }
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = [
+              "repo:hackforla/incubator:ref:refs/heads/*",
+              "repo:hackforla/incubator:pull_request"
+            ]
+          }
+        }
+      }
+    ]
+  })
 }
+
+resource "aws_iam_role_policy_attachment" "incubator_tf_plan_readonly" {
+  role      = aws_iam_role.incubator_tf_plan.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
 resource "aws_iam_role" "incubator_tf_apply" {
   name = "incubator-tf-apply"
 
@@ -40,7 +61,10 @@ resource "aws_iam_role" "incubator_tf_apply" {
             "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
           }
           StringLike = {
-            "token.actions.githubusercontent.com:sub" = "repo:hackforla/incubator:ref:refs/heads/main"
+            "token.actions.githubusercontent.com:sub" = [
+              "repo:hackforla/incubator:ref:refs/heads/main",
+              "repo:hackforla/incubator:pull_request"
+            ]
           }
         }
       }
@@ -50,6 +74,6 @@ resource "aws_iam_role" "incubator_tf_apply" {
 
 resource "aws_iam_role_policy_attachment" "incubator_tf_apply_admin" {
   role       = aws_iam_role.incubator_tf_apply.name
-  policy_arn  = "arn:aws:iam::aws:policy/AdministratorAccess"
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 

--- a/terraform/aws-gha-oidc-providers.tf
+++ b/terraform/aws-gha-oidc-providers.tf
@@ -9,4 +9,47 @@ module "iam_oidc_gha_incubator" {
   policy_arns = [
     "arn:aws:iam::aws:policy/AdministratorAccess"
   ]
+
 }
+module "iam_oidc_incubator_tf_plan" {
+  source = "./modules/aws-gha-oidc-providers"
+
+  role_name     = "incubator-tf-plan"
+  use_wildcard  = true
+  github_branch = "refs/heads/*" # concerning IAM audit, ok, as it is read-only
+  github_repo   = "hackforla/incubator"
+
+  policy_arns = [
+    "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  ]
+}
+resource "aws_iam_role" "incubator_tf_apply" {
+  name = "incubator-tf-apply"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Principal = {
+          Federated = module.iam_oidc_gha_incubator.provider_arn
+        }
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:hackforla/incubator:ref:refs/heads/main"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "incubator_tf_apply_admin" {
+  role       = aws_iam_role.incubator_tf_apply.name
+  policy_arn  = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+

--- a/terraform/aws-groups.tf
+++ b/terraform/aws-groups.tf
@@ -10,14 +10,3 @@ module "iam_read_only_group" {
   }
 }
 
-// Create iam services admin group
-module "iam_services_supervisor_group" {
-  source = "./modules/aws-groups"
-
-  group_name = "iam-services-supervisor-group"
-  policy_arn = {
-    "IAMServicesSupervisor" = module.aws_custom_policies.policy_arns["IAMServicesSupervisor"],
-    "EnforceMFAForUsers"    = module.aws_custom_policies.policy_arns["EnforceMFAForUsers"]
-  }
-}
-

--- a/terraform/aws-users.tf
+++ b/terraform/aws-users.tf
@@ -29,7 +29,7 @@ module "iam_user_chelseyb" {
     "Project"      = "devops-security"
     "Access Level" = "1"
   }
-  user_groups = ["read-only-group", "iam-services-supervisor-group"]
+  user_groups = ["read-only-group"]
 }
 
 
@@ -135,7 +135,7 @@ module "iam_user_raibarra" {
 module "iam_user_ezesalvatore4" {
   source = "./modules/aws-users"
 
-  user_name = "ezesalvatore" 
+  user_name = "ezesalvatore"
   user_tags = {
     "Project"      = "devops-security"
     "Access Level" = "1"


### PR DESCRIPTION
1/2 Done for #146

### What changes did you make?
  - **this PR does not perform the YAML file section of this issue**
  - Added a new GitHub Actions OIDC role `incubator-tf-plan` with **ReadOnlyAccess** for Terraform plan jobs.
  - Added a new GitHub Actions OIDC role `incubator-tf-apply` with **AdministratorAccess** and a trust policy restricted to repo:hackforla/incubator:ref:refs/heads/main(in consideration of IAM best practices). 
  - Left the existing gha-incubator role unchanged to avoid breaking anything(can change, if needed). 

### Why did you make the changes (we will use this info to test)?
  - The issue asked for it.
  - What this _should_ do is implement separate plan and apply roles so plan runs with read-only permissions, and apply can only run from the main branch.
  - I didn't use `policy_arns = ["arn:aws:iam::aws:policy/AdministratorAccess" ]` in the same way `iam_oidc_gha_incubator` does to separate the privilege definitions(I believe I understand this correctly- open to being corrected).

