### PR TITLE
Created resources and import statements to import ops-leads

### DIFF
--- a/terraform/aws-groups.tf
+++ b/terraform/aws-groups.tf
@@ -10,3 +10,19 @@ module "iam_read_only_group" {
   }
 }
 
+//import ops-leads group
+resource "aws_iam_group" "ops_leads_group" {
+	name = "ops-leads"
+}
+
+resource "aws_iam_group_policy_attachment" "admin"{
+	group = aws_iam_group.ops_leads_group.name
+	policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+} 
+
+resource "aws_iam_group_policy_attachment" "manageAccessKeys"{
+	group = aws_iam_group.ops_leads_group.name
+	policy_arn = "arn:aws:iam::035866691871:policy/ManageAccessKeys"
+} 
+
+	

--- a/terraform/imports.tf
+++ b/terraform/imports.tf
@@ -2,3 +2,12 @@ import {
 	to = aws_iam_group.ops_leads_group
 	id = "ops-leads"
 }
+
+import {
+ 	to = aws_iam_group_policy_attachment.admin
+	id = "ops-leads/arn:aws:iam::aws:policy/AdministratorAccess"
+}
+import {
+ 	to = aws_iam_group_policy_attachment.manageAccessKeys
+	id = "ops-leads/arn:aws:iam::035866691871:policy/ManageAccessKeys"
+}

--- a/terraform/imports.tf
+++ b/terraform/imports.tf
@@ -1,0 +1,4 @@
+import {
+	to = aws_iam_group.ops_leads_group
+	id = "ops-leads"
+}


### PR DESCRIPTION
Fixes #156 

### What changes did you make?
  - Created terraform resources for ops-leads(IAM Group and IAM policies)
  - Added import statement to connect terraform resources with existing aws resource
  -

### Why did you make the changes (we will use this info to test)?
  - In order for new members to onboard we need to have all groups represented in terraform
  - ops-leads is only represented in aws, so we need to bring it's representation into terraform code
  - import block will be removed after this is complete

